### PR TITLE
Updating github link to the right user

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,7 +24,7 @@
           <img src="/images/logo-big.png">
           <p>Grupo de desenvolvedores de Ruby / Rails de Pernambuco</p>
 
-          <li><a href="http://github.com/frevoonrails" class="github replacement" target="_blank">github.com/frevoonrails</a> </li>
+          <li><a href="http://github.com/frevo-on-rails" class="github replacement" target="_blank">github.com/frevoonrails</a> </li>
           <li><a href="http://twitter.com/abrilproruby" class="twitter replacement" target="_blank">twitter.com/abrilproruby</a> </li>
           <li><a href="http://www.facebook.com/frevoonrails" class="facebook replacement" target="_blank">facebook.com/frevoonrails</a> </li>
         </ul>


### PR DESCRIPTION
The Github link on the social part of the site is pointing to the wrong user in Github.
