### PR TITLE
Remove dead (and invisible) Google Plus link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,7 +27,6 @@
           <li><a href="http://github.com/frevo-on-rails" class="github replacement" target="_blank">github.com/frevoonrails</a> </li>
           <li><a href="http://twitter.com/abrilproruby" class="twitter replacement" target="_blank">twitter.com/abrilproruby</a> </li>
           <li><a href="http://www.facebook.com/frevoonrails" class="facebook replacement" target="_blank">facebook.com/frevoonrails</a> </li>
-          <li><a href="https://plus.google.com/116485832805325207155" class="gplus replacement" rel="publisher"  target="_blank">Google+</a></li>
         </ul>
       </header>
 


### PR DESCRIPTION
May Google Plus rest in peace. :coffin: