### PR TITLE
Post do evento de fevereiro de 2025

### DIFF
--- a/_posts/2025-01-15-encontro-de-fevereiro-2025.markdown
+++ b/_posts/2025-01-15-encontro-de-fevereiro-2025.markdown
@@ -1,0 +1,78 @@
+---
+layout     : post
+title      : "Encontro de Fevereiro/2025"
+date       : 2025-01-15 10:00:00
+author     : Angelo Maia
+categories : posts, events
+---
+
+A maior comunidade Ruby em linha reta do mundo convida para seu próximo encontro!
+
+## Data e hora
+
+26 de Fevereiro, às 18h.
+
+## Local
+
+A definir.
+
+## Agenda
+
+- XX:XXh~XX:XXh ~ Rodada de Apresentações
+- XX:XXh~XX:XXh ~ XXXX ~ XXXXX
+- XX:XXh~XX:XXh ~ XXXX ~ XXXXX
+- XX:XXh~XX:XXh ~ Mesa Redonda ~ XXXXX
+
+## Palestrantes
+
+A definir.
+
+## Organizadores
+
+### Walmir Neto
+
+[Walmir](https://walmir.dev) Web Software Developer @ [Lavenda](https://lavenda.com.br)
+
+### Haderson Almeida
+
+[Haderson](https://www.linkedin.com/in/haderson-almeida-5056b35b) Head of Products @ [Propósito Digital](https://www.linkedin.com/company/proposito-digital)
+
+### Matheus Santana
+
+[Matheus](https://embs.github.io) Staff Software Engineer @ [KnowBe4](https://www.knowbe4.com)
+
+### Lucas Moura
+
+[Lucas Moura](https://www.linkedin.com/in/lucas-santana-moura/) Senior Software Engineer @ Cast
+
+### Walter Silva
+
+Walter Silva
+
+### Ana Carolina Torchia
+
+[Ana Carolina Torchia](https://www.linkedin.com/in/ana-carolina-torchia/) Full Stack Developer
+
+### Pablo Jorge Maciel
+
+[Pablo Jorge Maciel](https://www.linkedin.com/in/pjmaciel/) Full Stack Developer
+
+### Raoni Xavier
+
+[Raoni Xavier](https://www.linkedin.com/in/raoni-xavier/) QA / Tester
+
+### Angelo Maia
+
+[Angelo Maia](https://www.linkedin.com/in/angelo-jamil-maia/) Software Developer @ [Rebase](https://rebase.com.br)
+
+### Pablo Morato
+
+[Pablo Morato](https://www.linkedin.com/in/pablomorato1/) Ruby on Rails Engineer
+
+## Inscrições
+
+Em breve.
+
+## Apoio
+
+Em breve. Quer apoiar? Chega aí!


### PR DESCRIPTION
Cria um `post` com as informações do encontro de fevereiro de 2025, ainda com tópicos a definir (local, palestrantes, inscrições...)